### PR TITLE
General Improvements and Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,63 @@ print(user.user_reviews(nick))
 ```
 </details>
 
-## **user_diary and user_diary_page and user_films_rated**
+## **user_diary_page and user_films_rated**
 
  To be documented.
+
+## **user_diary(user object)**
+
+```python
+from letterboxdpy import user
+nick = user.User("nmcassa")
+print(user.user_diary(nick))
+```
+
+<details>
+  <summary>Click to expand user_diary method response</summary>
+
+```json
+{
+    "entrys": {
+        "513520182": {
+            "name": "Black Swan",
+            "slug": "black-swan",
+            "id": "20956",
+            "release": 2010,
+            "rewatched": false,
+            "rating": 9,
+            "liked": true,
+            "reviewed": false,
+            "date": {
+                "year": 2024,
+                "month": 1,
+                "day": 15
+            },
+            "page": 1
+        },...
+        ...},
+        "129707465": {
+            "name": "mid90s",
+            "slug": "mid90s",
+            "id": "370451",
+            "release": 2018,
+            "rewatched": false,
+            "rating": 8,
+            "liked": false,
+            "reviewed": false,
+            "date": {
+                "year": 2020,
+                "month": 10,
+                "day": 20
+            },
+            "page": 7
+        }
+    },
+    "count": 337,
+    "last_page": 7
+}
+```
+</details>
 
 ## **Member Listing and top_users **
 

--- a/README.md
+++ b/README.md
@@ -199,22 +199,52 @@ print(user.user_reviews(nick))
 ```json
 {
     "reviews": {
-        "poor-things-2023": {
-            "movie": "Poor Things",
-            "movie_id": "710352",
-            "movie_year": 2023,
+        "495592379": {
+            "movie": {
+                "name": "Poor Things",
+                "slug": "poor-things-2023",
+                "id": "710352",
+                "release": 2023,
+                "link": "ltrbxd.com/film/poor-things-2023/"
+            },
+            "type": "Watched",
+            "no": 0,
+            "link": "ltrbxd.com/nmcassa/film/poor-things-2023/",
             "rating": 6,
-            "review": "It looks like AI art and weird movie",
-            "date": "26 Dec 2023"
+            "review": {
+                "content": "It looks like AI art and weird movie",
+                "spoiler": false
+            },
+            "date": {
+                "year": 2023,
+                "month": 12,
+                "day": 26
+            },
+            "page": 1
         },
-        "sisu-2022": {
-            "movie": "Sisu",
-            "movie_id": "755504",
-            "movie_year": 2022,
-            "rating": 5,
-            "review": "gross",
-            "date": "03 May 2023"
-        },...
+        "152420824": {
+            "movie": {
+                "name": "I'm Thinking of Ending Things",
+                "slug": "im-thinking-of-ending-things",
+                "id": "430806",
+                "release": 2020,
+                "link": "ltrbxd.com/film/im-thinking-of-ending-things/"
+            },
+            "type": "Watched",
+            "no": 0,
+            "link": "ltrbxd.com/nmcassa/film/im-thinking-of-ending-things/",
+            "rating": 8,
+            "review": {
+                "content": "yeah i dont get it",
+                "spoiler": false
+            },
+            "date": {
+                "year": 2021,
+                "month": 2,
+                "day": 14
+            },
+            "page": 1
+        }
     },
     "count": 7,
     "last_page": 1

--- a/README.md
+++ b/README.md
@@ -364,9 +364,29 @@ king = movie.Movie("king kong", 2005)
 print(movie.movie_details(king))
 ```
 
+<details>
+  <summary>Click to expand movie_details method response</summary>
+
 ```json
-{'Country': ['New Zealand', 'USA', 'Germany'], 'Studio': ['Universal Pictures', 'WingNut Films', 'Big Primate Pictures', 'MFPV Film'], 'Language': ['English']}
+{
+  "Country": [
+    "New Zealand",
+    "USA",
+    "Germany"
+  ],
+  "Studio": [
+    "Universal Pictures",
+    "WingNut Films",
+    "Big Primate Pictures",
+    "MFPV Film"
+  ],
+  "Language": [
+    "English"
+  ]
+}
+
 ```
+</details>
 
 <h2 id="movie_description">movie_description(movie object)</h2>
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,24 @@ pip install letterboxdpy
 
 # Directory
  - [User Objects](#User)
+    - [user_genre_info](#user_genre_info)
+    - [user_following & user_followers](#user_following)
+    - [user_films_watched](#user_films_watched)
+    - [user_reviews](#user_reviews)
+    - [user_diary](#user_diary)
+    - [user_diary_page](#user_diary_page) (todo)
+    - [user_films_rated](#user_films_rated) (todo)
+ - [Members](#Members) (todo)
+    - [top_users](#top_users) (todo)
  - [Movie Objects](#Movie)
+    - [movie_details](#movie_details)
+    - [movie_description](#movie_description)
+    - [movie_popular_reviews](#movie_popular_reviews)
+    - [movie_tmdb_link](#movie_tmdb_link)
+    - [movie_watchers](#movie_watchers) (todo)
+    - [movie_poster](#movie_poster) (todo)
  - [List Objects](#List)
+    - [list_tags](#list_tags)
 
 <h1 id="User">User Objects</h1>
 
@@ -59,7 +75,7 @@ print(nick)
 ```
 </details>
 
-## **user_genre_info(user object)**
+<h2 id="user_genre_info">user_genre_info(user object)</h2>
 
 ```python
 from letterboxdpy import user
@@ -70,7 +86,7 @@ print(user.user_genre_info(nick))
 <details>
   <summary>Click to expand user_genre_info method response</summary>
 
-```python
+```json
 {
     "action":55,
     "adventure":101,
@@ -95,7 +111,7 @@ print(user.user_genre_info(nick))
 ```
 </details>
 
-## **user_following(user object) / user_followers(user object)**
+<h2 id="user_following">user_following(user object) / user_followers(user object)</h2>
 
 ```python
 from letterboxdpy import user
@@ -107,7 +123,7 @@ print(user.user_followers(nick))
 <details>
   <summary>Click to expand user_following & user_followers methods response</summary>
 
-```python
+```json
 {
     "ppark": {
         "display_name": "ppark"
@@ -132,7 +148,7 @@ print(user.user_followers(nick))
 ```
 </details>
 
-## **user_films_watched(user object)**
+<h2 id="user_films_watched">user_films_watched(user object)</h2>
 
 ```python
 from letterboxdpy import user
@@ -143,7 +159,7 @@ print(user.user_films_watched(nick))
 <details>
   <summary>Click to expand user_films_watched method response</summary>
 
-```python
+```json
 {
     "movies": {
         "godzilla-minus-one": {
@@ -169,7 +185,7 @@ print(user.user_films_watched(nick))
 ```
 </details>
 
-## **user_reviews(user object)**
+<h2 id="user_reviews">user_reviews(user object)</h2>
 
 ```python
 from letterboxdpy import user
@@ -180,7 +196,7 @@ print(user.user_reviews(nick))
 <details>
   <summary>Click to expand user_reviews method response</summary>
 
-```python
+```json
 {
     "reviews": {
         "poor-things-2023": {
@@ -206,11 +222,7 @@ print(user.user_reviews(nick))
 ```
 </details>
 
-## **user_diary_page and user_films_rated**
-
- To be documented.
-
-## **user_diary(user object)**
+<h2 id="user_diary">user_diary(user object)</h2>
 
 ```python
 from letterboxdpy import user
@@ -264,9 +276,21 @@ print(user.user_diary(nick))
 ```
 </details>
 
-## **Member Listing and top_users **
+<h2 id="user_diary_page">user_diary_page(user object)</h2>
 
- To be documented.
+[To be documented.](https://github.com/search?q=repo:nmcassa/letterboxdpy+user_diary_page)
+
+ <h2 id="user_films_rated">user_films_rated(user object)</h2>
+
+[To be documented.](https://github.com/search?q=repo:nmcassa/letterboxdpy+user_films_rated)
+
+<h1 id="Members">Members Objects</h1>
+
+[To be documented.](https://github.com/search?q=repo:nmcassa/letterboxdpy+MemberListing)
+
+<h2 id="top_users">top_users(members object)</h2>
+
+[To be documented.](https://github.com/search?q=repo:nmcassa/letterboxdpy+top_users)
 
 <h1 id="Movie">Movie Objects</h1>
 
@@ -332,7 +356,7 @@ print(house)
 ```
 </details>
 
-## **movie_details(movie object)**
+<h2 id="movie_details">movie_details(movie object)</h2>
 
 ```python
 from letterboxdpy import movie
@@ -340,11 +364,11 @@ king = movie.Movie("king kong", 2005)
 print(movie.movie_details(king))
 ```
 
-```python
+```json
 {'Country': ['New Zealand', 'USA', 'Germany'], 'Studio': ['Universal Pictures', 'WingNut Films', 'Big Primate Pictures', 'MFPV Film'], 'Language': ['English']}
 ```
 
-## **movie_description(movie object)**
+<h2 id="movie_description">movie_description(movie object)</h2>
 
 ```python
 from letterboxdpy import movie
@@ -356,7 +380,7 @@ print(movie.movie_description(king))
 In 1933 New York, an overly ambitious movie producer coerces his cast and hired ship crew to travel to mysterious Skull Island, where they encounter Kong, a giant ape who is immediately smitten with...
 ```
 
-## **movie_popular_reviews(movie object)**
+<h2 id="movie_popular_reviews">movie_popular_reviews(movie object)</h2>
 
 ```python
 from letterboxdpy import movie
@@ -367,7 +391,7 @@ print(movie.movie_popular_reviews(king))
 <details>
   <summary>Click to expand movie_popular_reviews method response</summary>
 
-```
+```json
 [
     {
         "reviewer":"BRAT",
@@ -389,7 +413,7 @@ print(movie.movie_popular_reviews(king))
 ```
 </details>
 
-## **movie_tmdb_link**
+<h2 id="movie_tmdb_link">movie_tmdb_link(movie object)</h2>
 
 ```python
 from letterboxdpy import movie
@@ -399,13 +423,13 @@ print(movie.movie_tmdb_link(rock))
 https://www.themoviedb.org/movie/1366/
 ```
 
-## **movie_watchers**
+<h2 id="movie_watchers">movie_watchers(movie object)</h2>
 
- To be documented 
+[To be documented.](https://github.com/search?q=repo:nmcassa/letterboxdpy+movie_watchers)
 
-## **movie_poster**
+<h2 id="movie_poster">movie_poster(movie object)</h2>
 
- To be documented.
+[To be documented.](https://github.com/search?q=repo:nmcassa/letterboxdpy+movie_poster)
 
 <h1 id="List">List Objects</h1>
 
@@ -440,7 +464,7 @@ print(list)
 ```
 </details>
 
-## **list_tags(list object)**
+<h2 id="list_tags">list_tags(list object)</h2>
 
 ```python
 from letterboxdpy import list

--- a/letterboxdpy/user.py
+++ b/letterboxdpy/user.py
@@ -256,55 +256,87 @@ def user_reviews(user: User) -> dict:
     return data
 
 
-def user_diary_page(user: User, page) -> list:
-    '''Returns the user's diary for a specific page'''
+def user_diary_page(user: User, page:int=1) -> dict:
+    '''
+    Returns the user's diary entries for a specific page.
 
-    if type(user) != User:
-        raise Exception("Improper parameter")
+    Returns:
+    - dict: A dictionary containing diary entries for the specified page.
+      Each entry is represented as a dictionary with details such as movie name,
+      release information,rewatch status, rating, like status, review status,
+      and the date of the entry.
+    '''
+    assert isinstance(user, User), "Improper parameter: user must be an instance of User."
 
-    page = user.get_parsed_page(
-        "https://letterboxd.com/" + user.username + "/films/diary/page/"+str(page)+"/")
-    ret = []
+    dom = user.get_parsed_page(
+        f"https://letterboxd.com/{user.username}/films/diary/page/{page}/")
 
-    data = page.find_all("tr", {"class": ["diary-entry-row"], })
-    month_year = ''
-    for item in data:
-        curr = {}
+    ret = {'entrys': {}}
 
-        curr['movie'] = item.find("h3").text  # movie title
-        curr['movie_id'] = item.find("h3").find('a')['href'].split('/')[3] # movie id
-        curr['rating'] = item.find(
-            "span", {"class": ["rating"], }).text.strip()  # movie rating
-        day = item.find(
-            "td", {"class": ["td-day diary-day center"], }).text  # rating date
+    table = dom.find("table", {"id": ["diary-table"], })
 
-        day = day.replace(' ', '').replace(' ', '')
+    if table:
+        # extract the headers of the table to use as keys for the entries
+        headers = [elem.text.lower() for elem in table.find_all("th")]
+        rows = dom.tbody.find_all("tr")
 
-        # Checks if the date is still in the same month. If not, it changes the month_year
-        tmp_monthyear = item.find(
-            "td", {"class": ["td-calendar"], }).text.replace(' ', '').replace(' ', '')
+        for row in rows:
+            # create a dictionary by mapping headers
+            # to corresponding columns in the row
+            cols = dict(zip(headers, row.find_all('td')))
 
-        if tmp_monthyear != '':
-            month_year = item.find("td", {"class": ["td-calendar"], }).text
+            poster = cols['film'].div
+            rating = cols["rating"].span
+            release = cols["released"].text
 
-        curr['date'] = day.strip() + ' ' + month_year.strip()  # rating date
-        ret.append(curr)
+            log_id = row["data-viewing-id"]
+            date = dict(zip(
+                    ["year", "month", "day"],
+                    map(int, cols['day'].a['href'].split('/')[-4:])
+                ))
+            name = poster.img["alt"] or row.h3.text
+            slug = poster["data-film-slug"]
+            id = poster["data-film-id"]
+            release = int(release) if len(release) else None
+            rewatched = "icon-status-off" not in cols["rewatch"]["class"]
+            is_rating = 'rated-' in ''.join(rating["class"])
+            rating = int(rating["class"][-1].split("-")[-1]) if is_rating else None
+            liked = bool(cols["like"].find("span", attrs={"class": "icon-liked"}))
+            reviewed = bool(cols["review"].a)
+
+            ret["entrys"][log_id] = {
+                "name": name,
+                "slug": slug,
+                "id":  id,
+                "release": release,
+                "rewatched": rewatched,
+                "rating": rating,
+                "liked": liked,
+                "reviewed": reviewed,
+                "date": date,
+                "page": page,
+            }
 
     return ret
 
 
-def user_diary(user: User) -> list:
+def user_diary(user: User) -> dict:
     '''Returns a list of dictionaries with the user's diary'''
     assert isinstance(user, User), "Improper parameter: user must be an instance of User."
     
-    ret = []
+    ret = {'entrys': {}}
     pagination = 1
     while True:
         page_result = user_diary_page(user, pagination)
-        ret.extend(page_result)
-        if len(page_result) < 50:
+        entrys = page_result['entrys']
+        ret['entrys'].update(entrys)
+        if len(entrys) < 50:
+            print(f"Last page: {pagination}")
             break
         pagination += 1
+
+    ret['count'] = len(ret['entrys'])
+    ret['last_page'] = pagination
 
     return ret
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests=2.31.0
-beautifulsoup4=4.12.3
-lxml=5.1.0
+requests==2.31.0
+beautifulsoup4==4.12.3
+lxml==5.1.0


### PR DESCRIPTION
1. [6186c01](https://github.com/nmcassa/letterboxdpy/pull/20/commits/6186c01c6763a1451ef1c5975b69b0518886422c): **Refactor user_diary and user_diary_page functions for improved structure**
   - [letterboxdpy/user.py](https://github.com/nmcassa/letterboxdpy/pull/20/commits/6186c01c6763a1451ef1c5975b69b0518886422c#diff-e78a5cae06b564030f7e8b09d6cd9b8af0755c618a2ecd7ff329fe2bfe2edb62)
      - user_diary_page
         - Updated method description and return type to return a dictionary.
         - Utilized assert statements for type checking.
         - Restructured the method to return a dictionary, attempting to convert table headers to dictionary keys for data extraction.
         - Enhanced the 'rating' variable to receive an integer value in the range of 0-10. Added a check for unrated movies (is_rating).
         - Improved the date extraction process and stored it as an integer in the dictionary.
         - Enriched the dictionary data by processing other information in the table, adding new keys such as 'liked', 'page', 'reviewed', 'rewatched'.
         - Organized the data based on the column id (log_id) within the dictionary, so now movies with the same slug (name) will be included in the dictionary.
      - user_diary
         - Previously returning a list, this function was restructured to return a dictionary.
         - Since this function retrieves all diary data for a user, it is dependent on user_diary_page. After processing, 'count' and 'last_page' keys were added to the dictionary.
2. [6c22b76](https://github.com/nmcassa/letterboxdpy/pull/20/commits/6c22b764fcb98a231ea68727c31b5ef1813b2dac): **Updated the README for user_diary method.**
   - [README.md](https://github.com/nmcassa/letterboxdpy/pull/20/commits/6c22b764fcb98a231ea68727c31b5ef1813b2dac#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
      - Documented the changes made in the previous commit for user_diary_page and user_diary in the README file.
      - Removed user_diary from the "To be documented." category, provided details on its usage, and explained the returned data.
3. [406fa8c](https://github.com/nmcassa/letterboxdpy/pull/20/commits/406fa8cf91c58f61ec7c908b20ab2d1f8539fb6f): **Fix version specification in requirements.txt**
   - [requirements.txt](https://github.com/nmcassa/letterboxdpy/pull/20/commits/406fa8cf91c58f61ec7c908b20ab2d1f8539fb6f#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552)
      - I seem to have made an interesting mistake here; perhaps my mind briefly wandered into batch file variable assignments. Upon closer inspection today, I realized that I used a single equals sign for assignments in this file. Oh no! I've corrected them by changing single equals signs to double equals signs (e.g., `lxml=5.1.0` ~> `lxml==5.1.0`).
4. [a7f650e](https://github.com/nmcassa/letterboxdpy/pull/20/commits/a7f650e3b15904af9497dc348c2a5c00d0419aaf):  **Update directories and reponse format**
   - [README.md](https://github.com/nmcassa/letterboxdpy/pull/20/commits/a7f650e3b15904af9497dc348c2a5c00d0419aaf#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
      - In the README file's directory section, I added nested lists to link to methods and converted most Markdown headers (##) to HTML headers.
      - For better readability, I changed the format of some JSON responses that were originally assigned as Python code blocks (```).
      - Added a redirecting link for visitors to search and find the incomplete method documentation titles on this repository. Placed a 'todo' expression next to the titles in the directory section for yet-to-be-completed documentation.
5. [fb47f10](https://github.com/nmcassa/letterboxdpy/pull/20/commits/fb47f1015c66a17616f9477ce29b0aa3811b1a42): **Edit movie_details response**
   - [README.md](https://github.com/nmcassa/letterboxdpy/pull/20/commits/fb47f1015c66a17616f9477ce29b0aa3811b1a42#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
      - Indented the JSON data here as well, as we use the "click to expand" method for JSON responses in the README.
6. [dec9853](https://github.com/nmcassa/letterboxdpy/pull/20/commits/dec9853a96ff2aff71c206ff1b8753dca7fe4486): **Update user_reviews method**
   - [letterboxdpy/user.py](https://github.com/nmcassa/letterboxdpy/pull/20/commits/dec9853a96ff2aff71c206ff1b8753dca7fe4486#diff-e78a5cae06b564030f7e8b09d6cd9b8af0755c618a2ecd7ff329fe2bfe2edb62)
      - user_reviews
7. [449e31c](https://github.com/nmcassa/letterboxdpy/pull/20/commits/449e31c95ced52d91fab5580b79ac4bc79a72680): **Updated method response for user_reviews**
   - [README.md](https://github.com/nmcassa/letterboxdpy/pull/20/commits/449e31c95ced52d91fab5580b79ac4bc79a72680#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)