### PR TITLE
Add 'title' to movie scrape + small fixes

### DIFF
--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -217,8 +217,12 @@ class Movie:
     # letterboxd.com/film/?
     def movie_runtime(self, dom) -> int:
         elem = dom.find("p", {"class": ["text-footer"]})
-        elem = elem.text if elem else None
-        self.runtime = int(elem.split('mins')[0].strip()) if 'mins' in elem else None
+        elem = elem.find_all(string=True, recursive=False)
+        for i in elem:
+            if 'min' in i.text:
+                self.runtime = int(i.split('min')[0].strip())
+                return
+        self.runtime = None
 
     # letterboxd.com/film/?
     def movie_tmdb_link(self, dom) -> str:

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -220,7 +220,7 @@ class Movie:
         elem = elem.find_all(string=True, recursive=False)
         for i in elem:
             if 'min' in i.text:
-                self.runtime = int(i.split('min')[0].strip())
+                self.runtime = int(i.split('min')[0].replace(',','').strip())
                 return
         self.runtime = None
 

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -117,7 +117,7 @@ class Movie:
     def movie_alternative_titles(self, dom):
         data = dom.find(attrs={'class': 'text-indentedlist'})
         text = data.text if data else None
-        titles = [i.strip() for i in text.split(',')] if text else None
+        titles = [i.strip() for i in text.split(', ')] if text else None
         self.alternative_titles = titles
 
     # letterboxd.com/film/?

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -24,6 +24,7 @@ class Movie:
         script = json_loads(script.text.split('*/')[1].split('/*')[0]) if script else None
 
         # one line contents
+        self.movie_title(dom)
         self.movie_runtime(dom)
         self.movie_rating(dom, script)
         self.movie_year(dom, script)
@@ -206,6 +207,13 @@ class Movie:
 
             self.popular_reviews.append(curr)
 
+    # letterboxd.com/film/?
+    def movie_title(self, dom) -> int:
+        elem = dom.find("section", {"id": ["featured-film-header"]})
+        elem = elem.find("h1")
+        elem = elem.text if elem else None
+        self.title = elem.strip()
+  
     # letterboxd.com/film/?
     def movie_runtime(self, dom) -> int:
         elem = dom.find("p", {"class": ["text-footer"]})

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -25,6 +25,7 @@ class Movie:
 
         # one line contents
         self.movie_title(dom)
+        self.movie_original_title(dom)
         self.movie_runtime(dom)
         self.movie_rating(dom, script)
         self.movie_year(dom, script)
@@ -213,7 +214,14 @@ class Movie:
         elem = elem.find("h1")
         elem = elem.text if elem else None
         self.title = elem.strip()
-  
+
+    # letterboxd.com/film/?
+    def movie_original_title(self, dom) -> int:
+        elem = dom.find("section", {"id": ["featured-film-header"]})
+        elem = elem.find("em")
+        elem = elem.text.strip("'’‘ ") if elem else None
+        self.original_title = elem
+      
     # letterboxd.com/film/?
     def movie_runtime(self, dom) -> int:
         elem = dom.find("p", {"class": ["text-footer"]})

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -127,7 +127,7 @@ class Movie:
         data = data.find_all("a") if data else None
 
         genres = []
-        if data != None:
+        if data is not None:
             for item in data:
                 url_parts = item['href'].split('/')
                 

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -126,15 +126,16 @@ class Movie:
         data = data.find_all("a") if data else None
 
         genres = []
-        for item in data:
-            url_parts = item['href'].split('/')
-            
-            genres.append({
-                'type': url_parts[2],
-                'name': item.text,
-                'slug': url_parts[3],
-                'url': self.DOMAIN + "/".join(url_parts)
-            })
+        if data != None:
+            for item in data:
+                url_parts = item['href'].split('/')
+                
+                genres.append({
+                    'type': url_parts[2],
+                    'name': item.text,
+                    'slug': url_parts[3],
+                    'url': self.DOMAIN + "/".join(url_parts)
+                })
 
         if genres and self.slug == genres[-1]['type']:
             genres.pop() # for show all button

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -200,7 +200,8 @@ class Movie:
 
             owner = item.find("strong", {"class": ["name"], })
             rating = item.find("span", {"class": ['rating'], })
-            review = item.find("div", {"class": ['body-text'], }).p
+            review = item.find("div", {"class": ['body-text'], })
+            review = review.p if review is not None else None
 
             curr['reviewer'] = owner.text if owner else None
             curr['rating'] = rating.text if rating else None

--- a/letterboxdpy/search.py
+++ b/letterboxdpy/search.py
@@ -27,7 +27,22 @@ class Search:
              "search_filter must be one of the following:",
              ", ".join(self.FILTERS)
              ])
-
+      
+      # Mirroring Letterboxd search string subs - may be incomplete
+      query = query.replace('%','%25')
+      query = query.replace('+','%2B')
+      query = query.replace('"','%22')
+      query = query.replace('#','%23')
+      query = query.replace('$','%24')
+      query = query.replace('&','%26')
+      query = query.replace(',','%2C')
+      query = query.replace(':','%3A')
+      query = query.replace(';','%3B')
+      query = query.replace('=','%3D')
+      query = query.replace('?','%3F')
+      query = query.replace('@','%40')
+      query = query.replace('/','+')
+      query = query.replace(' ','+')
       self.query = query
       self.search_filter = search_filter
       self.scraper = Scraper(self.DOMAIN)


### PR DESCRIPTION
Adds the ability to get the main title of the movie you scrape.

- fixes intra-number comma splits for alt titles (there's still an issue with alt titles w/ any commas in them, but this is an improvement)
- Returns None for empty genres instead of erroring