### PR TITLE
Refactor jsonify to return JSON string directly

### DIFF
--- a/letterboxdpy/user.py
+++ b/letterboxdpy/user.py
@@ -37,7 +37,7 @@ class User:
       return json_dumps(self, indent=2, cls=Encoder)
 
     def jsonify(self):
-      return json_loads(self.__str__())
+        return str(self)
 
     # letterboxd.com/?
     def user_avatar(self, dom) -> str:


### PR DESCRIPTION
`jsonify` called `__str__` to get a JSON string representation of the object and then call `json_loads` to parse it back into a dictionary. However, `__str__` already produces a valid JSON string therefore `jsonify` should directly return the output of `__str__`.

### Modification
```py
def __str__(self):
  return json_dumps(self, indent=2, cls=Encoder)

def jsonify(self):
  return str(self)
```
### Previous
```py
def __str__(self):
  return json_dumps(self, indent=2, cls=Encoder)

def jsonify(self):
  return json_loads(self.__str__())
```