### PR TITLE
feat(movie.py): add additional stats and cleaner code processing

### DIFF
--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -305,11 +305,11 @@ def movie_watchers(movie: Movie) -> dict:
     dom = dom.find("div", {"id": ["content-nav"]})
 
     data = {
-        'watch_count': movie.watch_count if movie.watch_count else 0,
+        'watch_count': movie.watch_count*bool(movie.watch_count),
         'fan_count': 0,
-        'like_count': movie.like_count if movie.like_count else 0,
+        'like_count': movie.like_count*bool(movie.like_count),
         'review_count': 0,
-        'list_count': movie.list_count if movie.list_count else 0
+        'list_count': movie.list_count*bool(movie.list_count)
     }
 
     if dom:

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -223,8 +223,7 @@ class Movie:
     def movie_title_id(self, script) -> str:
         try:
             self.movie_title_id = script['url'].split('/')[4]
-        except Exception as e:
-            print(f"Error occurred while parsing movie title id: {e}")
+        except Exception:
             self.movie_title_id = ''
 
     # letterboxd.com/film/?

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -6,7 +6,6 @@ from json import (
   dumps as json_dumps,
   loads as json_loads,
 )
-from url import fetch_stats_url
 from utils import extract_numeric_text
 
 class Movie:

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -24,7 +24,6 @@ class Movie:
         script = json_loads(script.text.split('*/')[1].split('/*')[0]) if script else None
 
         # one line contents
-        self.movie_title_id(script)
         self.movie_id(dom)
         self.movie_title(dom)
         self.movie_original_title(dom)
@@ -210,17 +209,11 @@ class Movie:
             curr['review'] = review.text if review else None
 
             self.popular_reviews.append(curr)
-
-    def movie_title_id(self, script) -> str:
-        try:
-            self.movie_title_id = script['url'].split('/')[4]
-        except Exception:
-            self.movie_title_id = ''
     
     def movie_id(self, dom) -> str:
         elem = dom.find('span', 'block-flag-wrapper')
         elem = elem.find('a')
-        elem = elem.get('data-report-url').split('/')[2].split(':')[1] if elem else None
+        elem = extract_numeric_text(elem.get('data-report-url'))
         self.movie_id = elem
 
     # letterboxd.com/film/?

--- a/letterboxdpy/movie.py
+++ b/letterboxdpy/movie.py
@@ -6,8 +6,8 @@ from json import (
   dumps as json_dumps,
   loads as json_loads,
 )
-from url import fetchStatsUrl
-from utils import extractNumericText
+from url import fetch_stats_url
+from utils import extract_numeric_text
 
 class Movie:
     DOMAIN = 'https://letterboxd.com'
@@ -194,11 +194,11 @@ class Movie:
 
     # letterboxd.com/csi/film/?/stats
     def movie_stats(self) -> int:
-        statsUrl = fetchStatsUrl(self.movie_title_id)
-        statsDom = self.scraper.get_parsed_page(url=statsUrl)
-        self.watchCount = extractNumericText(statsDom.find('li', 'filmstat-watches').a.get('title'))
-        self.listAppCount = extractNumericText(statsDom.find('li', 'filmstat-lists').a.get('title'))
-        self.likeCount = extractNumericText(statsDom.find('li', 'filmstat-likes').a.get('title'))
+        stats_url = fetch_stats_url(self.movie_title_id)
+        stats_dom = self.scraper.get_parsed_page(url=stats_url)
+        self.watch_count = extract_numeric_text(stats_dom.find('li', 'filmstat-watches').a.get('title'))
+        self.list_count = extract_numeric_text(stats_dom.find('li', 'filmstat-lists').a.get('title'))
+        self.like_count = extract_numeric_text(stats_dom.find('li', 'filmstat-likes').a.get('title'))
 
     # letterboxd.com/film/?
     def movie_popular_reviews(self, dom) -> dict:
@@ -305,11 +305,11 @@ def movie_watchers(movie: Movie) -> dict:
     dom = dom.find("div", {"id": ["content-nav"]})
 
     data = {
-        'watch_count': movie.watchCount if movie.watchCount else 0,
+        'watch_count': movie.watch_count if movie.watch_count else 0,
         'fan_count': 0,
-        'like_count': movie.likeCount if movie.likeCount else 0,
+        'like_count': movie.like_count if movie.like_count else 0,
         'review_count': 0,
-        'list_count': movie.listAppCount if movie.listAppCount else 0
+        'list_count': movie.list_count if movie.list_count else 0
     }
 
     if dom:

--- a/letterboxdpy/url.py
+++ b/letterboxdpy/url.py
@@ -1,0 +1,2 @@
+def fetchStatsUrl(film_id: str) -> str:
+  return f"https://letterboxd.com/csi/film/{film_id}/stats/"

--- a/letterboxdpy/url.py
+++ b/letterboxdpy/url.py
@@ -1,2 +1,2 @@
-def fetchStatsUrl(film_id: str) -> str:
+def fetch_stats_url(film_id: str) -> str:
   return f"https://letterboxd.com/csi/film/{film_id}/stats/"

--- a/letterboxdpy/utils.py
+++ b/letterboxdpy/utils.py
@@ -1,6 +1,6 @@
 import re
 
-def extractNumericText(tag) -> int:
+def extract_numeric_text(tag) -> int:
   try:
     return int(re.sub(r"[^0-9]", '', tag))
   except Exception as e:

--- a/letterboxdpy/utils.py
+++ b/letterboxdpy/utils.py
@@ -3,6 +3,5 @@ import re
 def extract_numeric_text(tag) -> int:
   try:
     return int(re.sub(r"[^0-9]", '', tag))
-  except Exception as e:
-    print(f"Error occurred while parsing for numeric text: {e}")
-    return tag.text
+  except Exception:
+    return None

--- a/letterboxdpy/utils.py
+++ b/letterboxdpy/utils.py
@@ -1,0 +1,8 @@
+import re
+
+def extractNumericText(tag) -> int:
+  try:
+    return int(re.sub(r"[^0-9]", '', tag))
+  except Exception as e:
+    print(f"Error occurred while parsing for numeric text: {e}")
+    return tag.text


### PR DESCRIPTION
Discovered something interesting while I was building my own parsing script for a dashboard project I'm working on involving a list I made.

Here's the description from the commit that I'll leave you with since it's self-explanatory:

> this change is pretty simple: it uses another endpoint that i found while inspecting the network tab of a single film page and discovered a separate endpoint that they use to initially get some fetched statistics. its pretty useful to protect against edge cases where the film page in question DOES NOT have a significant number of impressions (ex. fringe asian films)

Forgot to add that since we're dealing with a lazy-loaded DOM, it makes sense that a separate endpoint must be storing some of the missing stats.

Happy to answer any queries/advice if you think there's some additional concerns regarding this PR. 

## Changelog
4/17/24:
- Removed the aforementioned `movie_stats` method as it is deemed redundant
- Stats to be added by this PR include: `movie_title_id` and `movie_id`
- Utility functions/scripts to be added:
  - `url.py`: a separate script to house all extraneous endpoints that may/may not be discovered while developing this package
  - `utils.py`: a utility python script that could be useful across other scripts for cleaner processing of code. Current function available under this is `extract_numeric_text` 