### PR TITLE
update search functionality for ajax results

### DIFF
--- a/letterboxdpy/search.py
+++ b/letterboxdpy/search.py
@@ -10,8 +10,8 @@ from letterboxdpy.scraper import (
 
 class Search:
     DOMAIN = "https://letterboxd.com"
-    SEARCH_URL = f"{DOMAIN}/search"
-    MAX_RESULTS = 250
+    SEARCH_URL = f"{DOMAIN}/s/search"
+    MAX_RESULTS = 20 # 250
     MAX_RESULTS_PER_PAGE = 20
     MAX_RESULTS_PAGE = MAX_RESULTS // MAX_RESULTS_PER_PAGE + 1
     FILTERS = ['films', 'reviews', 'lists', 'original-lists',

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,9 @@
-from letterboxdpy.user import User, user_films_liked
+from letterboxdpy.user import (
+    User,
+    user_followers,
+    user_following,
+    user_films_liked
+)
 import unittest
 
 
@@ -12,6 +17,13 @@ class TestUser(unittest.TestCase):
         values = movies.values()
 
         self.assertTrue(all(value['liked'] for value in values))
+    
+    def test_network_data(self):
+        followers = user_followers(self.user)
+        following = user_following(self.user)
+
+        self.assertTrue(self.user.stats['followers'] == len(followers))
+        self.assertTrue(self.user.stats['following'] == len(following))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a955c552-f111-4546-91b4-ad5c11e7886a)

**result limitation:**
- updated `search_url` to use ajax for fetching search results due to letterboxd's change in data display
- adjusted `max_results` to 20 to reflect the new maximum results per page

**implications:**
- you will now receive at most 20 results per search query
- pagination using the `end_page` parameter will not be effective beyond the limit of 20 results
