### PR TITLE
refactor(utils_parser): split parse_review_date into specific parsers with type annotations

### DIFF
--- a/letterboxdpy/utils/utils_parser.py
+++ b/letterboxdpy/utils/utils_parser.py
@@ -1,9 +1,13 @@
 import re
+from bs4 import Tag
+from typing import Dict, Literal, Optional
 
-MONTH_ABBREVIATIONS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", 
-                       "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+MONTH_ABBREVIATIONS = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+]
 
-def extract_numeric_text(text: str) -> int:
+def extract_numeric_text(text: str) -> Optional[int]:
     """
     Extracts numeric characters from a string and returns them as an integer.
     Returns None if an error occurs.
@@ -11,32 +15,34 @@ def extract_numeric_text(text: str) -> int:
     try:
         numeric_value = int(re.sub(r"[^0-9]", '', text))
         return numeric_value
-    except Exception:
+    except ValueError:
         return None
 
-def parse_review_date(review_log_type, review_date):
-    """
-    Parses review date depending on log type.
-    returns: {'year': 2024, 'month': 1, 'day': 1}
-    """
+def parse_iso_date(iso_date_str: str) -> Dict[str, int]:
+    """Parses an ISO 8601 formatted date string."""
+    try:
+        # ISO 8601 format example: '2025-01-01T00:00:00Z'
+        date_parts = list(map(int, iso_date_str[:10].split('-')))
+        return {'year': date_parts[0], 'month': date_parts[1], 'day': date_parts[2]}
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"Error parsing ISO date format: {e}")
+
+def parse_written_date(written_date_str: str) -> Dict[str, int]:
+    """Parses a written date string (e.g., '01 Jan 2025')."""
+    try:
+        date_parts = written_date_str.split()
+        return {
+            'year': int(date_parts[2]),
+            'month': MONTH_ABBREVIATIONS.index(date_parts[1]) + 1,
+            'day': int(date_parts[0])
+        }
+    except (IndexError, ValueError) as e:
+        raise ValueError(f"Error parsing written date format: {e}")
+
+def parse_review_date(
+        review_log_type: Literal['Rewatched', 'Watched', 'Added'],
+        review_date: Tag) -> Dict[str, int]:
+    """Parses the review date based on log type."""
     if review_log_type == 'Added':
-        try:
-            # ISO 8601 format: '2024-01-01T05:45:00.268Z'
-            date_parts = map(int, review_date.time['datetime'][:10].split('-'))
-            parsed_date = dict(zip(['year', 'month', 'day'], date_parts))
-        except (KeyError, ValueError) as e:
-            raise ValueError(f"Error parsing ISO date format: {e}")
-    else:
-        try:
-            # '01 Jan 2024' format
-            date_parts = review_date.text.split()
-            parsed_date = {
-                'year': int(date_parts[2]),
-                'month': MONTH_ABBREVIATIONS.index(date_parts[1]) + 1,
-                'day': int(date_parts[0])
-            }
-            
-        except (IndexError, ValueError) as e:
-            raise ValueError(f"Error parsing written date format: {e}")
-    
-    return parsed_date
+        return parse_iso_date(review_date.time['datetime'])
+    return parse_written_date(review_date.text)


### PR DESCRIPTION
- added `parse_iso_date` function to handle ISO 8601 formatted date strings
- added `parse_written_date` function to handle written date strings
- updated `parse_review_date` function to delegate to specific parsers based on log type