### PR TITLE
add month and day filters for user diary and improve follow stats handling

### DIFF
--- a/examples/follow_stats.py
+++ b/examples/follow_stats.py
@@ -27,7 +27,6 @@ def analyze_follow_stats(username: str) -> dict:
             'fans': list(followers_set - following_set)
         }
 
-    username = username.lower()
     user_instance = user.User(username)
     followers = user_instance.get_followers()
     following = user_instance.get_following()

--- a/examples/follow_stats.py
+++ b/examples/follow_stats.py
@@ -4,12 +4,12 @@ from json import dumps as json_dumps
 
 try:
     from letterboxdpy import user
-    from letterboxdpy.utils.utils_terminal import get_input
+    from letterboxdpy.utils.utils_terminal import get_input, args_exists
 except ImportError:
     try:
         sys.path.append(os.path.join(sys.path[0], '..'))
         from letterboxdpy import user
-        from letterboxdpy.utils.utils_terminal import get_input
+        from letterboxdpy.utils.utils_terminal import get_input, args_exists
     except (ImportError, ValueError) as e:
         raise ImportError(f"Error importing 'letterboxdpy': {e}. Please install the package.") from e
 
@@ -35,6 +35,9 @@ def analyze_follow_stats(username: str) -> dict:
     return calculate_stats(following, followers)
 
 if __name__ == "__main__":
+    if not args_exists():
+        print(f'Quick usage: python {sys.argv[0]} <username>')
+
     username = get_input("Enter username: ", index=1)
     stats = analyze_follow_stats(username)
     print(json_dumps(stats, indent=4))

--- a/letterboxdpy/constants/project.py
+++ b/letterboxdpy/constants/project.py
@@ -1,7 +1,10 @@
 from datetime import datetime
 
 # Date/Time Constants
-CURRENT_YEAR = datetime.now().year
+now = datetime.now()
+CURRENT_YEAR = now.year
+CURRENT_MONTH = now.month
+CURRENT_DAY = now.day
 MONTH_ABBREVIATIONS = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"

--- a/letterboxdpy/pages/user_diary.py
+++ b/letterboxdpy/pages/user_diary.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from letterboxdpy.core.scraper import parse_url
-from letterboxdpy.constants.project import DOMAIN, CURRENT_YEAR
+from letterboxdpy.constants.project import DOMAIN, CURRENT_YEAR, CURRENT_MONTH, CURRENT_DAY
 
 
 class UserDiary:
@@ -9,21 +9,45 @@ class UserDiary:
         self.username = username
         self.url = f"{DOMAIN}/{username}/diary"
         
-    def get_diary(self, year: int=None, page: int=None) -> dict:
-        return extract_user_diary(self.username, year, page)
+    def get_diary(self, year: int=None, month: int=None, day: int=None, page: int=None) -> dict:
+        return extract_user_diary(self.username, year, month, day, page)
+
+    def get_year(self, year: int=CURRENT_YEAR) -> dict:
+        return extract_user_diary(self.username, year)
+
+    def get_month(self, year: int=CURRENT_YEAR, month: int=CURRENT_MONTH) -> dict:
+        return extract_user_diary(self.username, year, month)
+
+    def get_day(self, year: int=CURRENT_YEAR, month: int=CURRENT_MONTH, day: int=CURRENT_DAY) -> dict:
+        return extract_user_diary(self.username, year, month, day)
 
     def get_wrapped(self, year: int=CURRENT_YEAR) -> dict:
         return extract_user_wrapped(self.username, year)
 
-def extract_user_diary(username: str, year: int=None, page: int=None) -> dict:
-    '''
+def extract_user_diary(
+        username: str,
+        year: int=None,
+        month: int=None,
+        day: int=None,
+        page: int=None) -> dict:
+    """
+    Extracts the user's diary entries, optionally filtering by year, month, and day.
+
+    Args:
+        username (str): The Letterboxd username.
+        year (int, optional): The year of diary entries.
+        month (int, optional): The month of diary entries.
+        day (int, optional): The day of diary entries.
+        page (int, optional): The page number for pagination.
+
     Returns:
-      Returns a list of dictionaries with the user's diary'
-      Each entry is represented as a dictionary with details such as movie name,
-      release information,rewatch status, rating, like status, review status,
-      and the date of the entry.
-    '''
-    BASE_URL = f"{DOMAIN}/{username}/films/diary/{f'for/{year}/'*bool(year)}"
+        dict: A dictionary with diary entries, each containing movie details, rewatch status, rating, like status, review status, and entry date.
+    """
+    date_filter = f"for/{year}/" if year else ""
+    date_filter += f"{str(month).zfill(2)}/" if month else ""
+    date_filter += f"{str(day).zfill(2)}/" if day else ""
+
+    BASE_URL = f"{DOMAIN}/{username}/films/diary/{date_filter}"
     pagination = page if page else 1
     ret = {'entries': {}}
 

--- a/letterboxdpy/user.py
+++ b/letterboxdpy/user.py
@@ -9,7 +9,7 @@ from json import (
 )
 
 from letterboxdpy.core.encoder import SecretsEncoder
-from letterboxdpy.constants.project import CURRENT_YEAR
+from letterboxdpy.constants.project import CURRENT_YEAR, CURRENT_MONTH, CURRENT_DAY
 from letterboxdpy.list import List as LetterboxdList
 from letterboxdpy.pages import (
     user_activity,
@@ -73,12 +73,18 @@ class User:
         return self.pages.activity.get_activity()
     def get_activity_following(self) -> dict:
         return self.pages.activity.get_activity_following()
-    
-    def get_diary(self, year: int = None, page: int = None) -> dict:
-        return self.pages.diary.get_diary(year, page)
+
+    def get_diary(self, year: int = None, month: int = None, day: int = None, page: int = None) -> dict:
+        return self.pages.diary.get_diary(year, month, day, page)
+    def get_diary_year(self, year: int = CURRENT_YEAR) -> dict:
+        return self.pages.diary.get_year(year)
+    def get_diary_month(self, year: int = CURRENT_YEAR, month: int = CURRENT_MONTH) -> dict:
+        return self.pages.diary.get_month(year, month)
+    def get_diary_day(self, year: int = CURRENT_YEAR, month: int = CURRENT_MONTH, day: int = CURRENT_DAY) -> dict:
+        return self.pages.diary.get_day(year, month, day)
     def get_wrapped(self, year: int = CURRENT_YEAR) -> dict:
         return self.pages.diary.get_wrapped(year)
-    
+
     def get_films(self) -> dict:
         return self.pages.films.get_films()
     def get_films_by_rating(self, rating: float | int) -> dict:


### PR DESCRIPTION
- added support for month and day filters in diary extraction.
- updated extract_user_diary to support filtering by month and day.
- modified user class to include new methods for retrieving diary entries by year, month, and day:
  - get_diary_year
  - get_diary_month
  - get_diary_day
- introduced current month and day constants to project constants.
- improved command-line argument handling for follow stats by adding args_exists check and usage instructions.
- removed redundant username.lower() call in follow stats.
