### PR TITLE
refactor: deduplicate review parsing logic (#72)

### DIFF
--- a/letterboxdpy/pages/user_activity.py
+++ b/letterboxdpy/pages/user_activity.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.constants.project import DOMAIN
+from letterboxdpy.utils.utils_parser import parse_review_text
 
 
 class UserActivity:
@@ -54,10 +55,7 @@ def extract_activity(username: str, ajax_url: str) -> dict:
             film_year = detail.h2.small.text
             film_year = int(film_year) if film_year else None
 
-            review = detail.find("div", {"class": ["body-text"], })
-            spoiler = bool(review.find("p", {"class": ["contains-spoilers"], }))
-            review = review.find_all('p')[1 if spoiler else 0:]
-            review = '\n'.join([p.text for p in review])
+            review, spoiler = parse_review_text(detail)
 
             return {
                 'type': log_type,

--- a/letterboxdpy/pages/user_reviews.py
+++ b/letterboxdpy/pages/user_reviews.py
@@ -1,5 +1,5 @@
 from letterboxdpy.core.scraper import parse_url
-from letterboxdpy.utils.utils_parser import parse_review_date
+from letterboxdpy.utils.utils_parser import parse_review_date, parse_review_text
 from letterboxdpy.constants.project import DOMAIN
 
 
@@ -58,11 +58,7 @@ def extract_user_reviews(username: str) -> dict:
             rating = log.find("span", {"class": ["rating"], })
             rating = int(rating['class'][-1].split('-')[-1]) if rating else None
             # int ^^^--- rating: the numerical value of the rating given in the review (1-10)
-            review = log.find("div", {"class": ["body-text"], })
-            spoiler = bool(review.find("p", {"class": ["contains-spoilers"], }))
-            # bool ^^^--- spoiler: whether the review contains spoiler warnings
-            review = review.find_all('p')[1 if spoiler else 0:]
-            review = '\n'.join([p.text for p in review])
+            review, spoiler = parse_review_text(log)
             # str ^^^--- review: the text content of the review.
             #            spoiler warning is checked to include or exclude the first paragraph.
             date = log.find("span", {"class": ["date"], })

--- a/letterboxdpy/utils/utils_parser.py
+++ b/letterboxdpy/utils/utils_parser.py
@@ -205,3 +205,32 @@ def catch_error_message(dom) -> Union[bool, str]:
             err = error_section.p.get_text()
             return err.split('\n')[0].strip()
     return False
+
+def parse_review_text(dom_element):
+    """
+    Parse review text from a DOM element, handling spoiler warnings.
+    
+    Args:
+        dom_element: DOM element containing the review (BeautifulSoup element)
+        
+    Returns:
+        tuple: (review_text, has_spoiler)
+            - review_text (str): Parsed review text with spoiler warnings properly handled.
+                                Returns empty string if no review content found.
+            - has_spoiler (bool): True if spoiler warning is present, False otherwise.
+             
+    Note:
+        If spoiler warning is present, skips the first paragraph.
+        Otherwise includes all paragraphs starting from the first one.
+    """
+    if not dom_element:
+        return "", False
+        
+    review = dom_element.find("div", {"class": ["body-text"]})
+    if not review:
+        return "", False
+        
+    spoiler = bool(review.find("p", {"class": ["contains-spoilers"]}))
+    review_paragraphs = review.find_all('p')[1 if spoiler else 0:]
+    review_text = '\n'.join([p.text for p in review_paragraphs])
+    return review_text, spoiler


### PR DESCRIPTION
- Add parse_review_text helper function to utils_parser.py
- Remove duplicated review parsing code from user_activity.py
- Remove duplicated review parsing code from user_reviews.py
- Helper function returns both review text and spoiler status
- Maintains backward compatibility and functionality

Fixes #72 - Eliminates code duplication while preserving behavior