### PR TITLE
Fix user lists scraping issues (#102, #109)

### DIFF
--- a/letterboxdpy/pages/user_lists.py
+++ b/letterboxdpy/pages/user_lists.py
@@ -8,8 +8,8 @@ class UserLists:
         self.username = username
         self.url = f"{DOMAIN}/{self.username}/lists"
         
-    def get_lists(self) -> dict: 
-        return ListsExtractor.from_url(self.url)
+    def get_lists(self, max_lists: int = None) -> dict: 
+        return ListsExtractor.from_url(self.url, max_lists)
 
 if __name__ == "__main__":
     lists_instance = UserLists("fastfingertips")


### PR DESCRIPTION
## Fixed Issues
Closes #102 
Closes #109

## Summary
Fixed two critical issues with user lists scraping:
- **Issue #102**: KeyError: 'data-film-id' when scraping user lists
- **Issue #109**: user.lists returns empty data

## Changes Made
- Updated HTML structure parsing to use `article.list-summary` (new Letterboxd structure)
- Added `max_lists` parameter for flexible list extraction
- Improved number parsing using existing `extract_numeric_text` utility
- Fixed infinite loop in pagination logic

## Testing
- [x] Tested with large lists (19K+ movies)
- [x] Tested with normal lists (50 movies)
- [x] Tested pagination limits
- [x] Verified shorthand number conversion (46K → 46000)

## Files Changed
- `letterboxdpy/pages/user_lists.py` - Added max_lists parameter
- `letterboxdpy/utils/lists_extractor.py` - Updated HTML parsing & pagination logic

## Usage
```python
# Get all lists (unlimited)
lists = user.pages.lists.get_lists()

# Get first 10 lists only
lists = user.pages.lists.get_lists(max_lists=10)
```