### PR TITLE
fix liked list entries

### DIFF
--- a/letterboxdpy/utils/activity_extractor.py
+++ b/letterboxdpy/utils/activity_extractor.py
@@ -299,7 +299,11 @@ def process_basic_activity(section, title: str, log_type: str, item_slug: str = 
                 'display_name': target.get_text().strip(),
                 'profile_url': f"https://letterboxd.com{href}" if href.startswith('/') else href
             }
-    
+
+    # The user liked a list
+    elif log_type == 'liked' and not item_slug:
+        activity_data['list'] = get_liked_list_data(section)
+
     elif log_type in ['liked', 'watched', 'added', 'rated']:
         # Extract movie information for film-related activities
         movie_data = {}
@@ -370,7 +374,10 @@ def get_log_item_slug(event_type: str, section) -> str | None:
 
     if event_type == "basic":
         anchor_tag = section.find("a", {"class": "target"})
-        item_slug = anchor_tag.attrs['href'].split('/')[-2]
+        anchor_href = anchor_tag.get('href')
+        if '/list/' in anchor_href or not anchor_href:
+            return None
+        item_slug = anchor_href.split('/')[-2]
         return item_slug
     
     elif event_type == "review":
@@ -379,3 +386,12 @@ def get_log_item_slug(event_type: str, section) -> str | None:
         return item_slug
     
     return None
+
+def get_liked_list_data(section):
+    anchor_tag = section.find("a", {"class": "target"})
+    anchor_href = anchor_tag.get('href')
+    liked_list_data = {
+        "title": anchor_tag.text,
+        "url": f"https://letterboxd.com{anchor_href}"
+    }
+    return liked_list_data


### PR DESCRIPTION
I have fixed a little bug where **liked list** where treated as a movie 

from this:
```json
"9714176250": {
    "activity_type": "basic",
    "timestamp": "2025-09-01T01:14:09.687000Z",
    "content": {
        "action": "liked",
        "description": "oooguuh liked Vesey\u2019s Rotoscoping list",
        "movie": {
            "title": "Rotoscoping",
            "slug": "rotoscoping",
            "url": "https://letterboxd.com/film/rotoscoping/"
        }
    }
}
```

to this:
```json
"9714176250": {
    "activity_type": "basic",
    "timestamp": "2025-09-01T01:14:09.687000Z",
    "content": {
        "action": "liked",
        "description": "oooguuh liked Vesey\u2019s Rotoscoping list",
        "list": {
            "title": "Rotoscoping",
            "url": "https://letterboxd.com/vesey/list/rotoscoping/"
        }
    }
}
```