### PR TITLE
fix: resolve watchlist_movies returning empty data

### DIFF
--- a/letterboxdpy/utils/movies_extractor.py
+++ b/letterboxdpy/utils/movies_extractor.py
@@ -77,7 +77,7 @@ def extract_movies_from_vertical_list(dom, max_items=20*5) -> dict:
             'url': f'https://letterboxd.com/film/{movie_slug}/'
         }
 
-    items = dom.find_all("li", {"class": "posteritem"})
+    items = dom.find_all("li", {"class": "posteritem"}) or dom.find_all("li", {"class": "griditem"})
     movies = {}
     for item in items:
         if len(movies) >= max_items:


### PR DESCRIPTION
- Update extract_movies_from_vertical_list to handle both 'posteritem' and 'griditem' classes
- Letterboxd changed watchlist HTML structure from 'posteritem' to 'griditem' class
- Maintains backward compatibility with old structure
- Fixes issue #112 where user.watchlist_movies returned empty despite having movies

Closes #112