### PR TITLE
fix: movie slug extraction key in extractor

### DIFF
--- a/letterboxdpy/utils/movies_extractor.py
+++ b/letterboxdpy/utils/movies_extractor.py
@@ -31,7 +31,7 @@ def extract_movies_from_horizontal_list(dom, max_items=12*6) -> dict:
             
         movie_rating = float(item[rating_key]) if rating_key in item.attrs else None
         movie_id = item.div['data-film-id']
-        movie_slug = item.div['data-film-slug'] 
+        movie_slug = item.div['data-item-slug'] 
         movie_name = item.img['alt']
 
         movies[movie_id] = {


### PR DESCRIPTION
Changed the key for extracting movie slug from 'data-film-slug' to 'data-item-slug' to match the expected DOM structure.