### PR TITLE
Bump requirements to use minimal version constraints (#128)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ build-backend = "hatchling.build"
 name = "letterboxdpy"
 version = "5.3.7"
 dependencies = [
-    "requests==2.31.0",
-    "beautifulsoup4==4.12.3",
-    "lxml==5.1.0",
+    "requests>=2.31.0",
+    "beautifulsoup4>=4.12.3",
+    "lxml>=5.1.0",
     "validators"
 ]
 requires-python = ">=3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.31.0
-beautifulsoup4==4.12.3
-lxml==5.1.0
+requests>=2.31.0
+beautifulsoup4>=4.12.3
+lxml>=5.1.0
 validators


### PR DESCRIPTION
## Problem
Exact version pins (`==`) in requirements cause dependency conflicts and prevent automatic security updates.

## Solution
Changed to minimal version constraints (`>=`) for better compatibility:
- requests>=2.31.0
- beautifulsoup4>=4.12.3  
- lxml>=5.1.0
- validators
- 
## Testing
Verified all functionality works with updated requirements.

Fixes #128