### PR TITLE
feat(scraper): add configurable timeout class attribute (#141)

### DIFF
--- a/letterboxdpy/core/scraper.py
+++ b/letterboxdpy/core/scraper.py
@@ -23,6 +23,7 @@ class Scraper:
         "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
     }
     builder = "lxml"
+    timeout = (10, 30)  # (connect, read) in seconds; set None to disable
 
     def __init__(self, domain: str = headers['referer'], user_agent: str = headers["user-agent"]):
         """Initialize the scraper with the specified domain and user-agent."""
@@ -42,7 +43,7 @@ class Scraper:
     def _fetch(cls, url: str) -> requests.Response:
         """Fetch the HTML content from the specified URL."""
         try:
-            return requests.get(url, headers=cls.headers)
+            return requests.get(url, headers=cls.headers, timeout=cls.timeout)
         except requests.RequestException as e:
             raise PageLoadError(url, str(e))
 


### PR DESCRIPTION
Closes #141

Adds a configurable `timeout` class attribute to the **Scraper** class to prevent HTTP requests from hanging indefinitely.

Previously, `requests.get()` was called without a timeout, which could cause the process to hang for 48+ hours if the server never responded.

Default: **(10, 30)]** seconds (connect, read)

Usage:
- `Scraper.timeout = (5, 15)` to customize
- `Scraper.timeout = None` to disable