### PR TITLE
feat: switch from requests to curl_cffi for Cloudflare bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # letterboxdpy
 
-[![PyPI version](https://badge.fury.io/py/letterboxdpy.svg)](https://badge.fury.io/py/letterboxdpy)
+[![PyPI version](https://img.shields.io/pypi/v/letterboxdpy?color=blue)](https://pypi.org/project/letterboxdpy/)
+[![Python Version](https://img.shields.io/pypi/pyversions/letterboxdpy?color=blue)](https://pypi.org/project/letterboxdpy/)
+[![Wheel](https://img.shields.io/pypi/wheel/letterboxdpy?color=blue)](https://pypi.org/project/letterboxdpy/)
+[![License](https://img.shields.io/pypi/l/letterboxdpy?color=blue)](https://github.com/nmcassa/letterboxdpy/blob/main/LICENSE)
 [![Downloads](https://static.pepy.tech/personalized-badge/letterboxdpy?period=total&units=none&left_color=grey&right_color=blue&left_text=Downloads)](https://pepy.tech/project/letterboxdpy)
-![format](https://img.shields.io/pypi/format/letterboxdpy)
 
 ## Installation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,7 +24,7 @@ pip install -r examples/requirements.txt
 ## Requirements
 
 **letterboxdpy dependencies** (auto-installed with `pip install -e .`):
-- requests, beautifulsoup4, lxml, pykit
+- curl_cffi, beautifulsoup4, lxml, pykit
 
 **Example-specific dependencies** (install with `pip install -r examples/requirements.txt`):
 - matplotlib, numpy, pillow — *used by visualization scripts*

--- a/examples/export_user_diary_posters.py
+++ b/examples/export_user_diary_posters.py
@@ -8,7 +8,7 @@ Downloads movie posters from user's diary entries.
 - Skip existing files with size checking
 """
 
-import requests
+from curl_cffi import requests
 import sys
 import os
 from bs4 import Tag

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -4,7 +4,7 @@
 # letterboxdpy dependencies (auto-installed with: pip install -e .)
 # Listed here for reference only
 # ============================================
-# requests>=2.31.0
+# curl_cffi>=0.14.0
 # beautifulsoup4>=4.12.3
 # lxml>=5.1.0
 # pykit @ git+https://github.com/fastfingertips/pykit.git

--- a/letterboxdpy/core/scraper.py
+++ b/letterboxdpy/core/scraper.py
@@ -3,7 +3,7 @@ if __name__ == '__main__':
     sys.path.append(sys.path[0] + '/..')
 
 from bs4 import BeautifulSoup, Tag
-import requests
+from curl_cffi import requests
 from urllib.parse import quote
 
 from letterboxdpy.utils.utils_file import JsonFile
@@ -43,8 +43,8 @@ class Scraper:
     def _fetch(cls, url: str) -> requests.Response:
         """Fetch the HTML content from the specified URL."""
         try:
-            return requests.get(url, headers=cls.headers, timeout=cls.timeout)
-        except requests.RequestException as e:
+            return requests.get(url, headers=cls.headers, timeout=cls.timeout, impersonate="chrome")
+        except requests.errors.RequestException as e:
             raise PageLoadError(url, str(e))
 
     @classmethod
@@ -52,10 +52,10 @@ class Scraper:
         """Check the response for errors and raise an exception if found."""
         if response.status_code != 200:
             error_message = cls._get_error_message(response)
-            formatted_error_messagge = cls._format_error(url, response, error_message)
+            formatted_error_message = cls._format_error(url, response, error_message)
             if response.status_code == 403:
-                raise PrivateRouteError(formatted_error_messagge)
-            raise InvalidResponseError(formatted_error_messagge)
+                raise PrivateRouteError(formatted_error_message)
+            raise InvalidResponseError(formatted_error_message)
 
     @classmethod
     def _get_error_message(cls, response: requests.Response) -> str:

--- a/letterboxdpy/url.py
+++ b/letterboxdpy/url.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING
-import requests
+from curl_cffi import requests
 from letterboxdpy.constants.project import DOMAIN
 from letterboxdpy.core.scraper import Scraper
 
@@ -20,7 +20,7 @@ class FilmURL:
         url = cls.json_url(slug)
         
         # Standalone fetch to avoid touching other files
-        response = requests.get(url, headers=Scraper.headers)
+        response = requests.get(url, headers=Scraper.headers, impersonate="chrome")
         if response.status_code != 200:
             from letterboxdpy.core.exceptions import InvalidResponseError
             raise InvalidResponseError(f"Failed to fetch JSON from {url}: {response.status_code}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,12 +6,12 @@ build-backend = "hatchling.build"
 name = "letterboxdpy"
 version = "5.3.7"
 dependencies = [
-    "requests>=2.31.0",
     "beautifulsoup4>=4.12.3",
     "lxml>=5.1.0",
+    "curl_cffi>=0.14.0",
     "pykit @ git+https://github.com/fastfingertips/pykit.git"
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
   { name="Nicholas Cassarino", email="nmcassa804@outlook.com" },
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.31.0
 beautifulsoup4>=4.12.3
 lxml>=5.1.0
+curl_cffi>=0.14.0
 pykit @ git+https://github.com/fastfingertips/pykit.git


### PR DESCRIPTION
### Summary
This PR replaces the requests library with curl_cffi to improve reliability and bypass modern bot protections like Cloudflare. This directly addresses the 403 Forbidden errors reported recently in #146.

### Related Issues
Fixes #146

### Changes
- **Core Scraper**: Updated Scraper to use curl_cffi.requests with impersonate='chrome'.
- **Dependencies**: 
  - Added curl_cffi>=0.14.0.
  - Removed requests.
  - Updated pyproject.toml and requirements.txt.
- **Environment**: Bumped minimum Python version to **3.9** (as required by newer curl_cffi versions).
- **Documentation**: 
  - Updated README with modern Shields.io badges (Wheel, Python 3.9+, License).
  - Updated examples/README.md to reflect the dependency change.
- **Examples**: Updated export_user_diary_posters.py to use curl_cffi.

### Rationale
Letterboxd has recently implemented more aggressive rate-limiting and bot detection, leading to the 403 errors described in #146. curl_cffi provides native TLS/JA3 and HTTP/2 fingerprinting, making it much more robust for scraping compared to pure-Python clients like requests or httpx.