### PR TITLE
fix: prevent double slashes in pagination URLs

### DIFF
--- a/letterboxdpy/pages/user_films.py
+++ b/letterboxdpy/pages/user_films.py
@@ -29,7 +29,7 @@ def extract_user_films(url: str) -> dict:
 
     def process_page(page_number: int) -> dict:
         """Fetches and processes a page of user films."""
-        dom = parse_url(f"{url}/page/{page_number}/")
+        dom = parse_url(f"{url.rstrip('/')}/page/{page_number}/")
         return extract_movies_from_user_watched(dom)
 
     def calculate_statistics(movies: dict) -> dict:

--- a/letterboxdpy/pages/user_list.py
+++ b/letterboxdpy/pages/user_list.py
@@ -92,7 +92,7 @@ def extract_movies(list_url: str, items_per_page) -> dict:
 
     page = 1
     while True:
-        dom = parse_url(f'{list_url}/page/{page}/')
+        dom = parse_url(f"{list_url.rstrip('/')}/page/{page}/")
         movies = extract_movies_from_vertical_list(dom)
         data |= movies
 

--- a/letterboxdpy/pages/user_network.py
+++ b/letterboxdpy/pages/user_network.py
@@ -28,7 +28,7 @@ def extract_network(username: str, section: str, limit: int = None, page: int = 
     def fetch_page(page_num: int):
         """Fetches a single page of the user's network section."""
         try:
-            return parse_url(f"{BASE_URL}/page/{page_num}")
+            return parse_url(f"{BASE_URL.rstrip('/')}/page/{page_num}")
         except Exception as e:
             raise PageFetchError(f"Failed to fetch page {page_num}: {e}") from e
 

--- a/letterboxdpy/pages/user_reviews.py
+++ b/letterboxdpy/pages/user_reviews.py
@@ -23,7 +23,7 @@ def extract_user_reviews(url: str) -> dict:
     data = {'reviews': {}}
     while True:
         page += 1
-        dom = parse_url(f"{url}/page/{page}/")
+        dom = parse_url(f"{url.rstrip('/')}/page/{page}/")
 
         container = dom.find("div", {"class": ["viewing-list"]})
 

--- a/letterboxdpy/pages/user_watchlist.py
+++ b/letterboxdpy/pages/user_watchlist.py
@@ -107,7 +107,7 @@ def extract_watchlist(username: str, filters: dict = None) -> dict:
     page = 1
     no = 1
     while True:
-        dom = parse_url(f'{BASE_URL}/page/{page}')
+        dom = parse_url(f"{BASE_URL.rstrip('/')}/page/{page}")
         containers = dom.find_all("li", {"class": "griditem"}) or dom.find_all("li", {"class": ["poster-container"]})
         
         for container in containers:

--- a/letterboxdpy/search.py
+++ b/letterboxdpy/search.py
@@ -56,7 +56,7 @@ class Search:
          }
 
       for current_page in range(1, end_page+1):
-        url = f'{self.url}/page/{current_page}/?adult'
+        url = f"{self.url.rstrip('/')}/page/{current_page}/?adult"
         dom = parse_url(url)
         results = self.get_page_results(dom)
 

--- a/letterboxdpy/utils/lists_extractor.py
+++ b/letterboxdpy/utils/lists_extractor.py
@@ -77,7 +77,7 @@ class ListsExtractor:
     @classmethod
     def _fetch_page_data(cls, base_url: str, page: int):
         """Fetch and parse page data."""
-        dom = parse_url(f'{base_url}/page/{page}')
+        dom = parse_url(f"{base_url.rstrip('/')}/page/{page}")
         return dom.find_all('article', {'class': 'list-summary'})
 
     @classmethod


### PR DESCRIPTION
This PR fixes the double slash (//) issue in pagination URLs by applying rstrip('/') to base URLs before appending the page path. This resolves 403 Forbidden errors on some endpoints.