### PR TITLE
fix: add missing trailing slashes to pagination URLs

### DIFF
--- a/letterboxdpy/pages/user_likes.py
+++ b/letterboxdpy/pages/user_likes.py
@@ -36,7 +36,7 @@ def extract_liked_reviews(url: str) -> dict:
 
     def process_page(page: int) -> list:
         """Process a single page and return list of review items."""
-        page_url = f"{url}/page/{page}" if page > 1 else url
+        page_url = f"{url.rstrip('/')}/page/{page}/" if page > 1 else url
         dom = parse_url(page_url)
         return dom.find_all("article", {"class": ["production-viewing"]})
 
@@ -193,7 +193,7 @@ def extract_liked_lists(url: str) -> dict:
     
     def process_page(page: int) -> list:
         """Process a single page and return list of list summaries."""
-        page_url = f"{url}/page/{page}" if page > 1 else url
+        page_url = f"{url.rstrip('/')}/page/{page}/" if page > 1 else url
         dom = parse_url(page_url)
         return dom.find_all('article', {'class': 'list-summary'})
     

--- a/letterboxdpy/pages/user_network.py
+++ b/letterboxdpy/pages/user_network.py
@@ -28,7 +28,7 @@ def extract_network(username: str, section: str, limit: int = None, page: int = 
     def fetch_page(page_num: int):
         """Fetches a single page of the user's network section."""
         try:
-            return parse_url(f"{BASE_URL.rstrip('/')}/page/{page_num}")
+            return parse_url(f"{BASE_URL.rstrip('/')}/page/{page_num}/")
         except Exception as e:
             raise PageFetchError(f"Failed to fetch page {page_num}: {e}") from e
 

--- a/letterboxdpy/pages/user_watchlist.py
+++ b/letterboxdpy/pages/user_watchlist.py
@@ -107,7 +107,7 @@ def extract_watchlist(username: str, filters: dict = None) -> dict:
     page = 1
     no = 1
     while True:
-        dom = parse_url(f"{BASE_URL.rstrip('/')}/page/{page}")
+        dom = parse_url(f"{BASE_URL.rstrip('/')}/page/{page}/")
         containers = dom.find_all("li", {"class": "griditem"}) or dom.find_all("li", {"class": ["poster-container"]})
         
         for container in containers:

--- a/letterboxdpy/utils/lists_extractor.py
+++ b/letterboxdpy/utils/lists_extractor.py
@@ -77,7 +77,7 @@ class ListsExtractor:
     @classmethod
     def _fetch_page_data(cls, base_url: str, page: int):
         """Fetch and parse page data."""
-        dom = parse_url(f"{base_url.rstrip('/')}/page/{page}")
+        dom = parse_url(f"{base_url.rstrip('/')}/page/{page}/")
         return dom.find_all('article', {'class': 'list-summary'})
 
     @classmethod


### PR DESCRIPTION
Some Letterboxd endpoints are sensitive to trailing slashes and return 403 Forbidden otherwise. This PR ensures all pagination URLs include the trailing slash.