### PR TITLE
refactor: centralize pagination URL logic

### DIFF
--- a/letterboxdpy/films.py
+++ b/letterboxdpy/films.py
@@ -5,6 +5,7 @@ if __loader__.name == '__main__':
 from letterboxdpy.utils.utils_transform import get_ajax_url
 from letterboxdpy.core.decorators import assert_instance
 from letterboxdpy.core.scraper import parse_url
+from letterboxdpy.utils.utils_url import get_page_url
 from letterboxdpy.utils.movies_extractor import extract_movies_from_horizontal_list, extract_movies_from_vertical_list
 
 class Films:
@@ -43,7 +44,7 @@ class Films:
         movies = {}
 
         while True:
-            page_url = self.ajax_url + f"/page/{page}"
+            page_url = get_page_url(self.ajax_url, page)
             dom = parse_url(page_url)
 
             if '.com/films/' in self.url:

--- a/letterboxdpy/members.py
+++ b/letterboxdpy/members.py
@@ -6,6 +6,7 @@ import re
 from letterboxdpy.core.encoder import Encoder
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.utils.utils_file import JsonFile
+from letterboxdpy.utils.utils_url import get_page_url
 
 
 class Members:
@@ -41,7 +42,7 @@ def top_users(max:int = 100) -> List:
     data = []
     page = 1
     while True:
-        url = f"{members_instance.MEMBERS_YEAR_TOP}page/{page}/"
+        url = get_page_url(members_instance.MEMBERS_YEAR_TOP, page)
         dom = parse_url(url)
 
         table = dom.find_all('table', {"class": ["member-table"]})[0]

--- a/letterboxdpy/pages/user_diary.py
+++ b/letterboxdpy/pages/user_diary.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.constants.project import DOMAIN, CURRENT_YEAR, CURRENT_MONTH, CURRENT_DAY
+from letterboxdpy.utils.utils_url import get_page_url
 
 
 class UserDiary:
@@ -63,7 +64,7 @@ def extract_user_diary(
     ret = {'entries': {}}
 
     while True:
-        url = BASE_URL + f"page/{pagination}/"
+        url = get_page_url(BASE_URL, pagination)
 
         dom = parse_url(url)
         table = dom.find("table", {"id": ["diary-table"], })

--- a/letterboxdpy/pages/user_films.py
+++ b/letterboxdpy/pages/user_films.py
@@ -1,5 +1,6 @@
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.constants.project import DOMAIN, GENRES
+from letterboxdpy.utils.utils_url import get_page_url
 
 
 class UserFilms:
@@ -29,7 +30,7 @@ def extract_user_films(url: str) -> dict:
 
     def process_page(page_number: int) -> dict:
         """Fetches and processes a page of user films."""
-        dom = parse_url(f"{url.rstrip('/')}/page/{page_number}/")
+        dom = parse_url(get_page_url(url, page_number))
         return extract_movies_from_user_watched(dom)
 
     def calculate_statistics(movies: dict) -> dict:

--- a/letterboxdpy/pages/user_likes.py
+++ b/letterboxdpy/pages/user_likes.py
@@ -2,7 +2,7 @@ from letterboxdpy.constants.project import DOMAIN
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.pages.user_films import extract_user_films
 from letterboxdpy.utils.utils_parser import parse_review_date, parse_iso_date
-from letterboxdpy.utils.utils_url import extract_path_segment
+from letterboxdpy.utils.utils_url import extract_path_segment, get_page_url
 
 
 class UserLikes:
@@ -36,7 +36,7 @@ def extract_liked_reviews(url: str) -> dict:
 
     def process_page(page: int) -> list:
         """Process a single page and return list of review items."""
-        page_url = f"{url.rstrip('/')}/page/{page}/" if page > 1 else url
+        page_url = get_page_url(url, page)
         dom = parse_url(page_url)
         return dom.find_all("article", {"class": ["production-viewing"]})
 
@@ -193,7 +193,7 @@ def extract_liked_lists(url: str) -> dict:
     
     def process_page(page: int) -> list:
         """Process a single page and return list of list summaries."""
-        page_url = f"{url.rstrip('/')}/page/{page}/" if page > 1 else url
+        page_url = get_page_url(url, page)
         dom = parse_url(page_url)
         return dom.find_all('article', {'class': 'list-summary'})
     

--- a/letterboxdpy/pages/user_list.py
+++ b/letterboxdpy/pages/user_list.py
@@ -6,6 +6,7 @@ from letterboxdpy.utils.utils_parser import get_meta_content, get_movie_count_fr
 from pykit.url_utils import urls_match
 from letterboxdpy.utils.movies_extractor import extract_movies_from_vertical_list
 from letterboxdpy.utils.date_utils import DateUtils
+from letterboxdpy.utils.utils_url import get_page_url
 
 
 class ListMetaData(dict):
@@ -92,7 +93,7 @@ def extract_movies(list_url: str, items_per_page) -> dict:
 
     page = 1
     while True:
-        dom = parse_url(f"{list_url.rstrip('/')}/page/{page}/")
+        dom = parse_url(get_page_url(list_url, page))
         movies = extract_movies_from_vertical_list(dom)
         data |= movies
 

--- a/letterboxdpy/pages/user_network.py
+++ b/letterboxdpy/pages/user_network.py
@@ -2,6 +2,7 @@ from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.constants.project import DOMAIN
 from letterboxdpy.core.exceptions import PageFetchError
 from letterboxdpy.avatar import Avatar
+from letterboxdpy.utils.utils_url import get_page_url
 
 
 class UserNetwork:
@@ -28,7 +29,7 @@ def extract_network(username: str, section: str, limit: int = None, page: int = 
     def fetch_page(page_num: int):
         """Fetches a single page of the user's network section."""
         try:
-            return parse_url(f"{BASE_URL.rstrip('/')}/page/{page_num}/")
+            return parse_url(get_page_url(BASE_URL, page_num))
         except Exception as e:
             raise PageFetchError(f"Failed to fetch page {page_num}: {e}") from e
 

--- a/letterboxdpy/pages/user_reviews.py
+++ b/letterboxdpy/pages/user_reviews.py
@@ -1,6 +1,7 @@
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.utils.utils_parser import parse_review_date, parse_review_text
 from letterboxdpy.constants.project import DOMAIN
+from letterboxdpy.utils.utils_url import get_page_url
 
 
 class UserReviews:
@@ -23,7 +24,7 @@ def extract_user_reviews(url: str) -> dict:
     data = {'reviews': {}}
     while True:
         page += 1
-        dom = parse_url(f"{url.rstrip('/')}/page/{page}/")
+        dom = parse_url(get_page_url(url, page))
 
         container = dom.find("div", {"class": ["viewing-list"]})
 

--- a/letterboxdpy/pages/user_watchlist.py
+++ b/letterboxdpy/pages/user_watchlist.py
@@ -5,6 +5,7 @@ Extracts watchlist data by scraping Letterboxd HTML pages.
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.constants.project import DOMAIN
 from letterboxdpy.pages.user_list import extract_movies
+from letterboxdpy.utils.utils_url import get_page_url
 
 class UserWatchlist:
     FILMS_PER_PAGE = 7*4
@@ -107,7 +108,7 @@ def extract_watchlist(username: str, filters: dict = None) -> dict:
     page = 1
     no = 1
     while True:
-        dom = parse_url(f"{BASE_URL.rstrip('/')}/page/{page}/")
+        dom = parse_url(get_page_url(BASE_URL, page))
         containers = dom.find_all("li", {"class": "griditem"}) or dom.find_all("li", {"class": ["poster-container"]})
         
         for container in containers:

--- a/letterboxdpy/search.py
+++ b/letterboxdpy/search.py
@@ -3,6 +3,7 @@ from letterboxdpy.utils.utils_parser import extract_and_convert_shorthand
 from letterboxdpy.core.encoder import Encoder
 from letterboxdpy.avatar import Avatar
 from letterboxdpy.constants.project import DOMAIN
+from letterboxdpy.utils.utils_url import get_page_url
 from letterboxdpy.core.scraper import (
   parse_url,
   url_encode
@@ -56,7 +57,7 @@ class Search:
          }
 
       for current_page in range(1, end_page+1):
-        url = f"{self.url.rstrip('/')}/page/{current_page}/?adult"
+        url = get_page_url(self.url, current_page, params="adult")
         dom = parse_url(url)
         results = self.get_page_results(dom)
 

--- a/letterboxdpy/utils/lists_extractor.py
+++ b/letterboxdpy/utils/lists_extractor.py
@@ -8,7 +8,7 @@ from letterboxdpy.utils.utils_parser import extract_and_convert_shorthand
 from pykit.string_utils import extract_number_from_text
 from letterboxdpy.core.scraper import parse_url
 from letterboxdpy.constants.project import DOMAIN
-from letterboxdpy.utils.utils_url import extract_path_segment
+from letterboxdpy.utils.utils_url import extract_path_segment, get_page_url
 
 
 class ListsExtractor:
@@ -77,7 +77,7 @@ class ListsExtractor:
     @classmethod
     def _fetch_page_data(cls, base_url: str, page: int):
         """Fetch and parse page data."""
-        dom = parse_url(f"{base_url.rstrip('/')}/page/{page}/")
+        dom = parse_url(get_page_url(base_url, page))
         return dom.find_all('article', {'class': 'list-summary'})
 
     @classmethod

--- a/letterboxdpy/utils/utils_url.py
+++ b/letterboxdpy/utils/utils_url.py
@@ -32,3 +32,17 @@ def parse_list_url(url: str) -> tuple:
     if match:
         return match.group(1), match.group(2)
     raise ValueError(f"Invalid list URL format: {url}")
+
+def get_page_url(base_url: str, page: int, params: str = "") -> str:
+    """
+    Generate a paginated URL from a base URL and page number.
+    Ensures no double slashes and consistent trailing slashes.
+    """
+    # Remove any trailing slashes from the base URL
+    clean_base = base_url.rstrip('/')
+    # Letterboxd standard pagination format: /page/N/
+    url = f"{clean_base}/page/{page}/"
+    if params:
+        # Append params, ensuring no double '?'
+        url += f"?{params.lstrip('?')}"
+    return url


### PR DESCRIPTION
 Introduced a centralized 'get_page_url' utility function to handle pagination URL construction consistently across the library. This ensures correct slash usage (Letterboxd prefers trailing slashes) and prevents double slash issues.