### PR TITLE
fix(list): retreive movie_id using data-postered-identifier instead o…

### DIFF
--- a/letterboxdpy/utils/movies_extractor.py
+++ b/letterboxdpy/utils/movies_extractor.py
@@ -5,6 +5,8 @@ This module provides generic functions to extract movie data from various
 Letterboxd page types that display movies in different layouts.
 """
 
+import warnings
+import json
 
 def extract_movies_from_horizontal_list(dom, max_items=12 * 6) -> dict:
     """
@@ -75,10 +77,21 @@ def extract_movies_from_vertical_list(dom, max_items=20 * 5) -> dict:
             if item.name == "li"
             else item
         )
-        if not react_component or "data-film-id" not in react_component.attrs:
+        if not react_component or "data-postered-identifier" not in react_component.attrs:
+            warnings.warn("Failed to get movie data")
             return None
 
-        movie_id = react_component["data-film-id"]
+        movie_uid = json.loads(react_component["data-postered-identifier"])["uid"]
+        if not isinstance(movie_uid, str):
+            warnings.warn("Invalid movie uid type")
+            return None
+
+        prefix, sep, value = movie_uid.partition(":")
+        if sep != ":" or prefix != "film" or not value.isdigit():
+            warnings.warn(f"Invalid movie uid format: {movie_uid!r}")
+            return None
+
+        movie_id = int(value)
         movie_slug = react_component.get("data-item-slug") or react_component.get(
             "data-film-slug"
         )

--- a/letterboxdpy/utils/movies_extractor.py
+++ b/letterboxdpy/utils/movies_extractor.py
@@ -5,8 +5,9 @@ This module provides generic functions to extract movie data from various
 Letterboxd page types that display movies in different layouts.
 """
 
-import warnings
 import json
+import warnings
+
 
 def extract_movies_from_horizontal_list(dom, max_items=12 * 6) -> dict:
     """
@@ -77,21 +78,24 @@ def extract_movies_from_vertical_list(dom, max_items=20 * 5) -> dict:
             if item.name == "li"
             else item
         )
-        if not react_component or "data-postered-identifier" not in react_component.attrs:
-            warnings.warn("Failed to get movie data")
+        if (
+            not react_component
+            or "data-postered-identifier" not in react_component.attrs
+        ):
+            warnings.warn("Failed to get movie data", stacklevel=2)
             return None
 
         movie_uid = json.loads(react_component["data-postered-identifier"])["uid"]
         if not isinstance(movie_uid, str):
-            warnings.warn("Invalid movie uid type")
+            warnings.warn("Invalid movie uid type", stacklevel=2)
             return None
 
         prefix, sep, value = movie_uid.partition(":")
         if sep != ":" or prefix != "film" or not value.isdigit():
-            warnings.warn(f"Invalid movie uid format: {movie_uid!r}")
+            warnings.warn(f"Invalid movie uid format: {movie_uid!r}", stacklevel=2)
             return None
 
-        movie_id = int(value)
+        movie_id = value
         movie_slug = react_component.get("data-item-slug") or react_component.get(
             "data-film-slug"
         )


### PR DESCRIPTION
There might have been an update on how the films are displayed in lists, now the `react_component` (that is built [here](https://github.com/nmcassa/letterboxdpy/blob/30dab6388a0cddf6851826801de2c87c57292b8f/letterboxdpy/utils/movies_extractor.py#L73-L76)) looks like 
```html
<div class="react-component" data-component-class="LazyPoster" data-details-endpoint="/film/la-la-land/json/"
    data-empty-poster-src="https://s.ltrbxd.com/static/img/empty-poster-125-AiuBHVCI.png" data-image-height="187"
    data-image-width="125" data-is-linked="true" data-item-full-display-name="La La Land (2016)"
    data-item-link="/film/la-la-land/" data-item-name="La La Land (2016)" data-item-slug="la-la-land"
    data-likeable="true" data-list-index="0" data-poster-url="/film/la-la-land/image-150/"
    data-postered-identifier='{"lid":"a5fa","uid":"film:240344","type":"film","typeName":"film"}' data-rateable="true"
    data-request-poster-metadata="true"
    data-resolvable-poster-path='{"postered":{"lid":"a5fa","uid":"film:240344","type":"film","typeName":"film"},"posteredBaseLink":"/film/la-la-land/","isAdultThemed":false,"hasDefaultPoster":true,"cacheBustingKey":"3e45390f"}'
    data-show-menu="true" data-target-link="/film/la-la-land/" data-watchable="true">
    <div class="poster film-poster"> <img alt="La La Land" class="image" height="187"
            src="https://s.ltrbxd.com/static/img/empty-poster-125-AiuBHVCI.png" width="125" /> <span class="frame"><span
                class="frame-title"></span></span> </div>
</div>
```

It does not contain the attribute `data-film-id`, but a more complexe structure, named `data-postered-identifier` which is of the form of a dictionnary with many elements in it.
The film id is present in the field `uid`.

The present patch corrects the parsing of the movies from a list.

```py
from letterboxdpy.list import List
list_instance = List("nmcassa", "movies-to-watch-with-priscilla-park")
print(list_instance.movies)
```


<details>
<summary>Output of the script (parsed and formatted so we can read it !)</summary>

```json
{
  "240344": {
    "slug": "la-la-land",
    "name": "La La Land",
    "year": 2016,
    "url": "https://letterboxd.com/film/la-la-land/"
  },
  "48049": {
    "slug": "carrie-1976",
    "name": "Carrie",
    "year": 1976,
    "url": "https://letterboxd.com/film/carrie-1976/"
  },
  "753420": {
    "slug": "robot-dreams",
    "name": "Robot Dreams",
    "year": 2023,
    "url": "https://letterboxd.com/film/robot-dreams/"
  },
  "55864": {
    "slug": "good-morning",
    "name": "Good Morning",
    "year": 1959,
    "url": "https://letterboxd.com/film/good-morning/"
  },
  "51777": {
    "slug": "amadeus",
    "name": "Amadeus",
    "year": 1984,
    "url": "https://letterboxd.com/film/amadeus/"
  },
  "51684": {
    "slug": "la-haine",
    "name": "La Haine",
    "year": 1995,
    "url": "https://letterboxd.com/film/la-haine/"
  },
  "51714": {
    "slug": "alien",
    "name": "Alien",
    "year": 1979,
    "url": "https://letterboxd.com/film/alien/"
  },
  "51818": {
    "slug": "the-godfather",
    "name": "The Godfather",
    "year": 1972,
    "url": "https://letterboxd.com/film/the-godfather/"
  },
  "50956": {
    "slug": "raging-bull",
    "name": "Raging Bull",
    "year": 1980,
    "url": "https://letterboxd.com/film/raging-bull/"
  },
  "51315": {
    "slug": "videodrome",
    "name": "Videodrome",
    "year": 1983,
    "url": "https://letterboxd.com/film/videodrome/"
  },
  "758794": {
    "slug": "unfrosted",
    "name": "Unfrosted",
    "year": 2024,
    "url": "https://letterboxd.com/film/unfrosted/"
  },
  "2699": {
    "slug": "the-fifth-element",
    "name": "The Fifth Element",
    "year": 1997,
    "url": "https://letterboxd.com/film/the-fifth-element/"
  },
  "25416": {
    "slug": "real-steel",
    "name": "Real Steel",
    "year": 2011,
    "url": "https://letterboxd.com/film/real-steel/"
  },
  "49455": {
    "slug": "scream",
    "name": "Scream",
    "year": 1996,
    "url": "https://letterboxd.com/film/scream/"
  },
  "28195": {
    "slug": "cure",
    "name": "Cure",
    "year": 1997,
    "url": "https://letterboxd.com/film/cure/"
  },
  "62780": {
    "slug": "mad-max-fury-road",
    "name": "Mad Max: Fury Road",
    "year": 2015,
    "url": "https://letterboxd.com/film/mad-max-fury-road/"
  },
  "705221": {
    "slug": "furiosa-a-mad-max-saga",
    "name": "Furiosa: A Mad Max Saga",
    "year": 2024,
    "url": "https://letterboxd.com/film/furiosa-a-mad-max-saga/"
  },
  "542449": {
    "slug": "minari",
    "name": "Minari",
    "year": 2020,
    "url": "https://letterboxd.com/film/minari/"
  },
  "772230": {
    "slug": "i-saw-the-tv-glow",
    "name": "I Saw the TV Glow",
    "year": 2024,
    "url": "https://letterboxd.com/film/i-saw-the-tv-glow/"
  }
}
```

</details>

close #164