### PR TITLE
bugfix: don't limit listcollection to one page

### DIFF
--- a/letterboxdpy/utils/lists_extractor.py
+++ b/letterboxdpy/utils/lists_extractor.py
@@ -48,7 +48,7 @@ class ListsExtractor:
         Returns:
             dict: Contains 'lists', 'count', 'last_page'
         """
-        data = {"limit": max_lists, "count": 0, "last_page": 1, "lists": {}}
+        data = {"limit": False, "count": 0, "last_page": 1, "lists": {}}
         page = 1
 
         while True:


### PR DESCRIPTION
I noticed a bug in the list extractor. Pagination didn't work if you used a limit, because the stop condition was initialized wrong.

Extracted from #174 