### PR TITLE
delay fetching movie members

### DIFF
--- a/letterboxdpy/pages/movie_members.py
+++ b/letterboxdpy/pages/movie_members.py
@@ -1,3 +1,6 @@
+from functools import cached_property
+
+from bs4 import BeautifulSoup
 from fastfingertips.string_utils import extract_number_from_text
 
 from letterboxdpy.constants.project import DOMAIN
@@ -11,7 +14,10 @@ class MovieMembers:
         """Initialize MovieMembers with a movie slug."""
         self.slug = slug
         self.url = f"{DOMAIN}/film/{slug}/members"
-        self.dom = parse_url(self.url)
+
+    @cached_property
+    def dom(self) -> BeautifulSoup:
+        return parse_url(self.url)
 
     def get_watchers_stats(self) -> dict:
         """Get movie watchers' statistics."""

--- a/tests/test_movie.py
+++ b/tests/test_movie.py
@@ -121,6 +121,19 @@ class TestMovie(unittest.TestCase):
         }
         self.assertIn(expected_director, directors)
 
+    def test_members(self):
+        stats = self.movie.get_watchers_stats()
+        self.assertGreater(stats["members"], 1_500_000)
+        self.assertLess(stats["members"], 3_000_000)
+        self.assertGreater(stats["fans"], 15_000)
+        self.assertLess(stats["fans"], 30_000)
+        self.assertGreater(stats["likes"], 400_000)
+        self.assertLess(stats["likes"], 800_000)
+        self.assertGreater(stats["reviews"], 90_000)
+        self.assertLess(stats["reviews"], 180_000)
+        self.assertGreater(stats["lists"], 150_000)
+        self.assertLess(stats["lists"], 300_000)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I would argue that 99% of the users don't care about the watch-stats of a movie. So it doesn't make sense to preload it whenever you load a single movie. So I delayed the request so that it's only done when somebody wants those infos.

Extracted from #174